### PR TITLE
add mac support

### DIFF
--- a/cmd/moby-components
+++ b/cmd/moby-components
@@ -143,7 +143,7 @@ transform_branch() {
 			mv \$GIT_INDEX_FILE.new \$GIT_INDEX_FILE;
 		fi
 	" --msg-filter "
-		sed '\${/^\$/d;p}' | head -n -1
+		sed '\${/^\$/d;p;}' | sed '\$d'
 		echo Upstream-commit: \$GIT_COMMIT
 		echo Component: $component
 	" $branch


### PR DESCRIPTION
changes:

* replaced `head -n -1` by `sed '\$d'` (GNU head doesn't support -1) [see link](https://github.com/avtobiff/erlang-uuid/issues/3)
* added `;` after `p` in sed  [see link](https://stackoverflow.com/questions/18127726/getting-head-to-display-all-but-the-last-line-of-a-file-command-substitution-an)


ping @andrewhsu @tiborvass 